### PR TITLE
57 smooth centroid tracks

### DIFF
--- a/lpt/helpers.py
+++ b/lpt/helpers.py
@@ -1390,6 +1390,10 @@ def fill_data_linear(xtime, y, time_interval_hours):
 
 
 def smooth_and_fill_tc(TC_this, time_interval_hours):
+    """
+    Run the centroid smoothing functions. Fill in data for the gaps when
+    the system fell below the threshold and recovered within the allowed time.
+    """
 
     REFTIME = cftime.datetime(1970,1,1,0,0,0,calendar=TC_this['datetime'][0].calendar) ## Only used internally.
 
@@ -1427,6 +1431,12 @@ def smooth_and_fill_tc(TC_this, time_interval_hours):
     ## Replace the TC information.
     TC_this_filled['timestamp'] = xtime_fill
     TC_this_filled['datetime'] = [REFTIME + dt.timedelta(seconds=x) for x in xtime_fill]
+
+    ## Set nobj to zero for the filled in periods, since there is no LPO.
+    ## This is the only indication I will have that the data was filled in.
+    for tt, this_xtime_fill in enumerate(xtime_fill):
+        if not this_xtime_fill in TC_this['timestamp']:
+            TC_this_filled['nobj'][tt] = 0
 
     ## Add in the smoothed centroids.
     TC_this_filled['centroid_lon_smoothed'] = lon_smooth

--- a/lpt/helpers.py
+++ b/lpt/helpers.py
@@ -1391,6 +1391,8 @@ def fill_data_linear(xtime, y, time_interval_hours):
 
 def smooth_and_fill_tc(TC_this, time_interval_hours):
 
+    REFTIME = cftime.datetime(1970,1,1,0,0,0,calendar=TC_this['datetime'][0].calendar) ## Only used internally.
+
     ## Calculate smoothed centroid track
     xtime_fill, lon_smooth, lat_smooth = smooth_centroid_track(
         TC_this['timestamp'],
@@ -1424,6 +1426,7 @@ def smooth_and_fill_tc(TC_this, time_interval_hours):
 
     ## Replace the TC information.
     TC_this_filled['timestamp'] = xtime_fill
+    TC_this_filled['datetime'] = [REFTIME + dt.timedelta(seconds=x) for x in xtime_fill]
 
     ## Add in the smoothed centroids.
     TC_this_filled['centroid_lon_smoothed'] = lon_smooth

--- a/lpt/lpt_driver.py
+++ b/lpt/lpt_driver.py
@@ -93,6 +93,7 @@ def lpt_driver(dataset,plotting,output,lpo_options,lpt_options
                     + '_' + str(int(lpo_options['accumulation_hours'])) + 'h'
                     + '/thresh' + str(int(lpo_options['thresh'])) + '/systems')
     options['calendar'] = dataset['calendar']
+    options['data_time_interval'] = dataset['data_time_interval']
 
     if options['do_lpt_calc']:
 
@@ -169,6 +170,10 @@ def lpt_driver(dataset,plotting,output,lpo_options,lpt_options
                 print('Splits and mergers retained as the same LPT system.', flush=True)
                 print('--- Calculating LPT System Properties. ---', flush=True)
                 TIMECLUSTERS = lpt.helpers.calc_lpt_properties_without_branches(G, options)
+
+
+            
+
 
         ## Output
         print('--- Writing output. ---',flush=True)

--- a/lpt/lptio.py
+++ b/lpt/lptio.py
@@ -311,6 +311,8 @@ def lpt_system_tracks_output_netcdf(fn, TIMECLUSTERS, units={}):
     nobj_collect = np.double([MISSING])
     centroid_lon_collect = np.array([MISSING])
     centroid_lat_collect = np.array([MISSING])
+    centroid_lon_smoothed_collect = np.array([MISSING])
+    centroid_lat_smoothed_collect = np.array([MISSING])
     largest_object_centroid_lon_collect = np.array([MISSING])
     largest_object_centroid_lat_collect = np.array([MISSING])
     max_lon_collect = np.array([MISSING])
@@ -364,6 +366,8 @@ def lpt_system_tracks_output_netcdf(fn, TIMECLUSTERS, units={}):
         nobj_collect = np.append(np.append(nobj_collect, TIMECLUSTERS[ii]['nobj']),MISSING)
         centroid_lon_collect = np.append(np.append(centroid_lon_collect, TIMECLUSTERS[ii]['centroid_lon']),MISSING)
         centroid_lat_collect = np.append(np.append(centroid_lat_collect, TIMECLUSTERS[ii]['centroid_lat']),MISSING)
+        centroid_lon_smoothed_collect = np.append(np.append(centroid_lon_smoothed_collect, TIMECLUSTERS[ii]['centroid_lon_smoothed']),MISSING)
+        centroid_lat_smoothed_collect = np.append(np.append(centroid_lat_smoothed_collect, TIMECLUSTERS[ii]['centroid_lat_smoothed']),MISSING)
         largest_object_centroid_lon_collect = np.append(np.append(largest_object_centroid_lon_collect, TIMECLUSTERS[ii]['largest_object_centroid_lon']),MISSING)
         largest_object_centroid_lat_collect = np.append(np.append(largest_object_centroid_lat_collect, TIMECLUSTERS[ii]['largest_object_centroid_lat']),MISSING)
         area_collect = np.append(np.append(area_collect, TIMECLUSTERS[ii]['area']),MISSING)
@@ -457,6 +461,10 @@ def lpt_system_tracks_output_netcdf(fn, TIMECLUSTERS, units={}):
         {'units':'degrees_east','long_name':'centroid longitude, may be inbetween objects (0-360) -- stitched','standard_name':'longitude'})
     data_dict['centroid_lat_stitched'] = (['nstitch'], centroid_lat_collect,
         {'units':'degrees_north','long_name':'centroid latitude, may be inbetween objects (-90-90) -- stitched','standard_name':'latitude'})
+    data_dict['centroid_lon_smoothed_stitched'] = (['nstitch'], centroid_lon_smoothed_collect,
+        {'units':'degrees_east','long_name':'centroid longitude, spline smoothed, may be inbetween objects (0-360) -- stitched','standard_name':'longitude'})
+    data_dict['centroid_lat_smoothed_stitched'] = (['nstitch'], centroid_lat_smoothed_collect,
+        {'units':'degrees_north','long_name':'centroid latitude, spline smoothed, may be inbetween objects (-90-90) -- stitched','standard_name':'latitude'})
     data_dict['largest_object_centroid_lon_stitched'] = (['nstitch'], largest_object_centroid_lon_collect,
         {'units':'degrees_east','long_name':'centroid longitude of the largest contiguous object (0-360) -- stitched','standard_name':'longitude'})
     data_dict['largest_object_centroid_lat_stitched'] = (['nstitch'], largest_object_centroid_lat_collect,

--- a/lpt/lptio.py
+++ b/lpt/lptio.py
@@ -536,6 +536,8 @@ def read_lpt_systems_netcdf(lpt_systems_file):
         TC['datetime'] = DS['timestamp_stitched'].data #[REFTIME + dt.timedelta(hours=int(x)) if x > -900000000 else None for x in TC['timestamp_stitched']]
         TC['centroid_lon'] = DS['centroid_lon_stitched'].data
         TC['centroid_lat'] = DS['centroid_lat_stitched'].data
+        TC['centroid_lon_smoothed'] = DS['centroid_lon_smoothed_stitched'].data
+        TC['centroid_lat_smoothed'] = DS['centroid_lat_smoothed_stitched'].data
         TC['largest_object_centroid_lon'] = DS['largest_object_centroid_lon_stitched'].data
         TC['largest_object_centroid_lat'] = DS['largest_object_centroid_lat_stitched'].data
         TC['area'] = DS['area_stitched'].data

--- a/lpt/masks.py
+++ b/lpt/masks.py
@@ -666,7 +666,7 @@ def calc_individual_lpt_masks(dt_begin, dt_end, interval_hours, prod='trmm'
     lpt_systems_file = (lpt_systems_dir + '/lpt_systems_'+prod+'_'+YMDH1_YMDH2+'.nc').replace('///','/').replace('//','/')
     # lpt_group_file = (lpt_systems_dir + '/lpt_systems_'+prod+'_'+YMDH1_YMDH2+'.group_array.txt').replace('///','/').replace('//','/')
 
-    MISSING = -999.0
+    MISSING = np.nan
     FILL_VALUE = MISSING
 
     ## Read Stitched data.
@@ -1066,15 +1066,19 @@ def calc_individual_lpt_masks(dt_begin, dt_end, interval_hours, prod='trmm'
         ##########################################################
         lptidx = [ii for ii in range(len(TC['lptid'])) if this_lpt_id == TC['lptid'][ii]][0]
 
-        basic_lpt_info_field_list = ['centroid_lon','centroid_lat','area'
-                    ,'largest_object_centroid_lon','largest_object_centroid_lat'
-                    ,'max_filtered_running_field','max_running_field','max_inst_field'
-                    ,'min_filtered_running_field','min_running_field','min_inst_field'
-                    ,'amean_filtered_running_field','amean_running_field','amean_inst_field']
+        basic_lpt_info_field_list = [
+            'centroid_lon','centroid_lat','area',
+            'centroid_lon_smoothed','centroid_lat_smoothed',
+            'largest_object_centroid_lon','largest_object_centroid_lat',
+            'max_filtered_running_field','max_running_field','max_inst_field',
+            'min_filtered_running_field','min_running_field','min_inst_field',
+            'amean_filtered_running_field','amean_running_field',
+            'amean_inst_field'
+        ]
 
         # Time varying properties
         for var in basic_lpt_info_field_list:
-            mask_arrays[var] = MISSING * np.ones(len(mask_times))
+            mask_arrays[var] = np.full(len(mask_times), MISSING)
 
         for ttt in range(TC['i1'][lptidx],TC['i2'][lptidx]+1):
             this_time_indx = [ii for ii in range(len(mask_times)) if TC['datetime'][ttt] == mask_times[ii]]
@@ -1126,6 +1130,8 @@ def calc_individual_lpt_masks(dt_begin, dt_end, interval_hours, prod='trmm'
         DS = xr.Dataset(data_vars=data_dict, coords=coords_dict)
         DS.centroid_lon.attrs = {'units':'degrees_east','long_name':'centroid longitude (0-360)','standard_name':'longitude','note':'Time is end of running mean time.'}
         DS.centroid_lat.attrs = {'units':'degrees_north','long_name':'centroid latitude (-90-00)','standard_name':'latitude','note':'Time is end of running mean time.'}
+        DS.centroid_lon_smoothed.attrs = {'units':'degrees_east','long_name':'centroid longitude (0-360), with spline smoothing','standard_name':'longitude','note':'Time is end of running mean time.'}
+        DS.centroid_lat_smoothed.attrs = {'units':'degrees_north','long_name':'centroid latitude (-90-00), with spline smoothing','standard_name':'latitude','note':'Time is end of running mean time.'}
         DS.largest_object_centroid_lon.attrs = {'units':'degrees_east','long_name':'centroid longitude (0-360)','standard_name':'longitude','note':'Time is end of running mean time.'}
         DS.largest_object_centroid_lat.attrs = {'units':'degrees_east','long_name':'centroid latitude (-90-00)','standard_name':'latitude','note':'Time is end of running mean time.'}
         DS.area.attrs = {'units':'km2','long_name':'LPT System enclosed area','note':'Time is end of running mean time.'}
@@ -1260,7 +1266,7 @@ def calc_individual_lpt_group_masks(dt_begin, dt_end, interval_hours, prod='trmm
     lpt_systems_file = (lpt_systems_dir + '/lpt_systems_'+prod+'_'+YMDH1_YMDH2+'.nc').replace('///','/').replace('//','/')
     lpt_group_file = (lpt_systems_dir + '/lpt_systems_'+prod+'_'+YMDH1_YMDH2+'.group_array.txt').replace('///','/').replace('//','/')
 
-    MISSING = -999.0
+    MISSING = np.nan
     FILL_VALUE = MISSING
 
     ## Read Stitched data.
@@ -1504,15 +1510,19 @@ def calc_individual_lpt_group_masks(dt_begin, dt_end, interval_hours, prod='trmm
         ##########################################################
         lptidx = [ii for ii in range(len(TC['lptid'])) if this_lpt_id == TC['lptid'][ii]][0]
 
-        basic_lpt_info_field_list = ['centroid_lon','centroid_lat','area'
-                    ,'largest_object_centroid_lon','largest_object_centroid_lat'
-                    ,'max_filtered_running_field','max_running_field','max_inst_field'
-                    ,'min_filtered_running_field','min_running_field','min_inst_field'
-                    ,'amean_filtered_running_field','amean_running_field','amean_inst_field']
+        basic_lpt_info_field_list = [
+            'centroid_lon','centroid_lat','area',
+            'centroid_lon_smoothed','centroid_lat_smoothed',
+            'largest_object_centroid_lon','largest_object_centroid_lat',
+            'max_filtered_running_field','max_running_field','max_inst_field',
+            'min_filtered_running_field','min_running_field','min_inst_field',
+            'amean_filtered_running_field','amean_running_field',
+            'amean_inst_field'
+        ]
 
         # Time varying properties
         for var in basic_lpt_info_field_list:
-            mask_arrays[var] = MISSING * np.ones(len(mask_times))
+            mask_arrays[var] = np.full(len(mask_times), MISSING)
 
         for ttt in range(TC['i1'][lptidx],TC['i2'][lptidx]+1):
             this_time_indx = [ii for ii in range(len(mask_times)) if TC['datetime'][ttt] == mask_times[ii]]


### PR DESCRIPTION
The LPT centroid tracks can be noisy. These changes address #57 by adding a set of smoothed tracks. The smoothing is done using a spline smoother. Two new variables are added to the LPT systems NetCDF files (centroid_lon_smoothed_stitched, centroid_lat_smoothed_stitched) and the individual LPT system mask files (centroid_lon_smoothed, centroid_lat_smoothed).

Doing this also filled in the gaps in the tracks that were created when some LPT systems fell below the LPO threshold then recovered within the allowed time period. To accommodate this, the "stitched" variables all have more entries than previously. For consistency, the non-smoothed variables are also filled in for these times. For now, this is done with linear interpolation, except for nobj, which is set to zero during the gap time periods, as there was no LPO identified for those times. Note that the only indication that the data were filled in is that nobj will be zero at those times.